### PR TITLE
👷 Use built-in GITHUB_TOKEN for the release job + bump to 3.3.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     needs: deploy
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -60,5 +62,5 @@ jobs:
         with:
           tag_name: v${{ steps.tag.outputs.version }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        continue-on-error: true # Ignore if no n
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true # Ignore if no new version (release already exists)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portfolio",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "type": "module",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
## Problem
The `create-release` job in `deploy.yml` silently failed to create the GitHub release for `v3.3.0`:

```
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main: HttpError: Bad credentials
##[error]Bad credentials
```

The custom `GH_TOKEN` PAT (mapped into `GITHUB_TOKEN`) is **expired/invalid**. Because the step has `continue-on-error: true`, the job still reported success — so the tag `v3.3.0` got pushed but no release was created.

## Fix
- Use the automatic `secrets.GITHUB_TOKEN` instead of the manually-maintained `GH_TOKEN` PAT.
- Add `permissions: contents: write` to the `create-release` job so the built-in token can push tags and create releases.
- Bump version `3.3.0 → 3.3.1`.

### Why the version bump
`actions/checkout@v4` does not fetch tags by default, so the job's "skip if tag exists" check never sees existing tags. Keeping `3.3.0` would make the next deploy try to re-push the existing `v3.3.0` tag → push rejected → release job fails before the release step runs. A fresh `3.3.1` avoids the tag collision and validates the new token by creating a real release.

No more PAT to rotate/maintain.

## Notes
- Does **not** retroactively create the missing `v3.3.0` release (handled separately).
- `softprops/action-gh-release@v1` + `actions/checkout` still emit a Node 20 deprecation warning — left to the github-actions Dependabot group.